### PR TITLE
POC: Turn Currency into a class

### DIFF
--- a/NodaMoney.sln
+++ b/NodaMoney.sln
@@ -20,6 +20,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NodaMoney.Tests", "tests\No
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "build\_build.csproj", "{324D342A-2588-4422-AFB1-FA0359EE825D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NodaMoney.Serialization.JsonNet", "src\NodaMoney.Serialization.JsonNet\NodaMoney.Serialization.JsonNet.csproj", "{EF8D8552-7B23-4D03-B2A9-03246087BE6B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +43,10 @@ Global
 		{CC01DEB3-F862-49A1-9EB5-50A4E52B82E7}.Release|Any CPU.Build.0 = Release|Any CPU
 		{324D342A-2588-4422-AFB1-FA0359EE825D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{324D342A-2588-4422-AFB1-FA0359EE825D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EF8D8552-7B23-4D03-B2A9-03246087BE6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EF8D8552-7B23-4D03-B2A9-03246087BE6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EF8D8552-7B23-4D03-B2A9-03246087BE6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EF8D8552-7B23-4D03-B2A9-03246087BE6B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NodaMoney.Serialization.AspNet/NodaMoney.Serialization.AspNet.csproj
+++ b/src/NodaMoney.Serialization.AspNet/NodaMoney.Serialization.AspNet.csproj
@@ -7,18 +7,12 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>NodaMoney.Serialization.AspNet</PackageId>
     <PackageTags>Noda;Money;Currency;ExchangeRate;Serialization</PackageTags>   
-    <TargetFrameworks>net40;net45</TargetFrameworks>   
+    <TargetFrameworks>net45</TargetFrameworks>   
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\NodaMoney\NodaMoney.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System.Web.Extensions" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/src/NodaMoney.Serialization.JsonNet/CurrencyJsonConverter.cs
+++ b/src/NodaMoney.Serialization.JsonNet/CurrencyJsonConverter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.ComponentModel;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace NodaMoney.Serialization.JsonNet
+{
+
+    public class CurrencyJsonConverter : JsonConverter<Currency>
+    {
+        private static TypeConverter currencyConverter = TypeDescriptor.GetConverter(typeof(Currency));
+        public override Currency ReadJson(JsonReader reader, Type objectType, Currency existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            var code = reader.Value.ToString();
+            return (Currency)currencyConverter.ConvertFromString(code);
+        }
+
+        public override void WriteJson(JsonWriter writer, Currency value, JsonSerializer serializer)
+        {
+            writer.WriteValue(currencyConverter.ConvertToString(value));
+        }
+    }
+}

--- a/src/NodaMoney.Serialization.JsonNet/Extensions.cs
+++ b/src/NodaMoney.Serialization.JsonNet/Extensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace NodaMoney.Serialization.JsonNet
+{
+    public static class Extensions
+    {
+        public static JsonSerializerSettings ConfigureForNodaMoney(this JsonSerializerSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            settings.Converters.Add(new MoneyJsonConverter());
+            settings.Converters.Add(new CurrencyJsonConverter());
+            return settings;
+        }
+    }
+}

--- a/src/NodaMoney.Serialization.JsonNet/MoneyJsonConverter.cs
+++ b/src/NodaMoney.Serialization.JsonNet/MoneyJsonConverter.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.ComponentModel;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace NodaMoney.Serialization.JsonNet
+{
+    public class MoneyJsonConverter : JsonConverter<Money>
+    {
+        private static TypeConverter currencyConverter = TypeDescriptor.GetConverter(typeof(Currency));
+        public override Money ReadJson(JsonReader reader, Type objectType, Money existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            decimal? amount = null;
+            string currencyCode = null;
+            var amountPropertyName = ResolvePropertyName(serializer, nameof(Money.Amount));
+            var currencyPropertyName = ResolvePropertyName(serializer, nameof(Money.Currency));
+
+            while (reader.Read())
+            {
+                if (reader.TokenType != JsonToken.PropertyName)
+                {
+                    break;
+                }
+
+                var propertyName = (string)reader.Value;
+
+                if (!reader.Read())
+                {
+                    break;
+                }
+
+                if (string.Equals(propertyName, amountPropertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    amount = serializer.Deserialize<decimal?>(reader);
+                }
+
+                if (string.Equals(propertyName, currencyPropertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    currencyCode = serializer.Deserialize<string>(reader);
+                }
+            }
+
+            if (amount == null)
+            {
+                throw new JsonSerializationException($"Unable to deserialize to {nameof(Money)}, since the property {amountPropertyName} was null or missing");
+            }
+
+            if (string.IsNullOrEmpty(currencyCode))
+            {
+                throw new JsonSerializationException($"Unable to deserialize to {nameof(Money)}, since the property {currencyPropertyName} was null or missing");
+            }
+
+            return new Money(amount.Value, (Currency)currencyConverter.ConvertFromString(currencyCode));
+        }
+
+        public override void WriteJson(JsonWriter writer, Money value, JsonSerializer serializer)
+        {
+            writer.WriteStartObject();
+
+            writer.WritePropertyName(ResolvePropertyName(serializer, nameof(Money.Amount)));
+            serializer.Serialize(writer, value.Amount);
+
+            writer.WritePropertyName(ResolvePropertyName(serializer, nameof(Money.Currency)));
+            writer.WriteValue(value.Currency.Code);
+
+            writer.WriteEndObject();
+        }
+
+        static string ResolvePropertyName(JsonSerializer serializer, string propertyName) =>
+                    (serializer.ContractResolver as DefaultContractResolver)?.GetResolvedPropertyName(propertyName) ?? propertyName;
+    }
+}

--- a/src/NodaMoney.Serialization.JsonNet/NodaMoney.Serialization.JsonNet.csproj
+++ b/src/NodaMoney.Serialization.JsonNet/NodaMoney.Serialization.JsonNet.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0;netstandard2.1;net45;net461;net5</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NodaMoney\NodaMoney.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/NodaMoney/CurrencyBuilder.cs
+++ b/src/NodaMoney/CurrencyBuilder.cs
@@ -140,6 +140,9 @@ namespace NodaMoney
         /// <param name="currency">The object whose properties will be used.</param>
         public void LoadDataFromCurrency(Currency currency)
         {
+            if (currency is null)
+                throw new ArgumentNullException(nameof(currency));
+
             EnglishName = currency.EnglishName;
             Symbol = currency.Symbol;
             ISONumber = currency.Number;

--- a/src/NodaMoney/CurrencyRegistry.cs
+++ b/src/NodaMoney/CurrencyRegistry.cs
@@ -44,7 +44,7 @@ namespace NodaMoney
             }
 
             currency = found.FirstOrDefault(); // TODO: If more than one, sort by prio.
-            return !currency.Equals(default);
+            return currency != null;
         }
 
         /// <summary>Tries the get <see cref="Currency"/> of the given code and namespace.</summary>

--- a/src/NodaMoney/Money.Parsable.cs
+++ b/src/NodaMoney/Money.Parsable.cs
@@ -36,6 +36,8 @@ namespace NodaMoney
         {
             if (string.IsNullOrWhiteSpace(value))
                 throw new ArgumentNullException(nameof(value));
+            if (currency is null)
+                throw new ArgumentNullException(nameof(currency));
 
             return Parse(value, NumberStyles.Currency, GetFormatProvider(currency, null), currency);
         }
@@ -53,6 +55,8 @@ namespace NodaMoney
         {
             if (string.IsNullOrWhiteSpace(value))
                 throw new ArgumentNullException(nameof(value));
+            if (currency is null)
+                throw new ArgumentNullException(nameof(currency));
 
             decimal amount = decimal.Parse(value, style, GetFormatProvider(currency, provider));
             return new Money(amount, currency);
@@ -101,6 +105,9 @@ namespace NodaMoney
         /// <remarks>See <see cref="decimal.TryParse(string, out decimal)"/> for more info and remarks.</remarks>
         public static bool TryParse(string value, Currency currency, out Money result)
         {
+            if (currency is null)
+                throw new ArgumentNullException(nameof(currency));
+
             return TryParse(value, NumberStyles.Currency, GetFormatProvider(currency, null), currency, out result);
         }
 
@@ -118,6 +125,9 @@ namespace NodaMoney
         /// <remarks>See <see cref="decimal.TryParse(string, NumberStyles, IFormatProvider, out decimal)"/> for more info and remarks.</remarks>
         public static bool TryParse(string value, NumberStyles style, IFormatProvider provider, Currency currency, out Money result)
         {
+            if (currency is null)
+                throw new ArgumentNullException(nameof(currency));
+
             bool isParsingSuccessful = decimal.TryParse(value, style, GetFormatProvider(currency, provider), out decimal amount);
             if (isParsingSuccessful)
             {

--- a/src/NodaMoney/Money.Serializable.cs
+++ b/src/NodaMoney/Money.Serializable.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Xml;
 using System.Xml.Schema;
@@ -53,8 +54,8 @@ namespace NodaMoney
                 currency = info.GetString("currency");
             }
 
-            Currency = (Currency)TypeDescriptor.GetConverter(typeof(Currency)).ConvertFromString(currency);
-            Amount = Round(amount, Currency, MidpointRounding.ToEven);
+            this.currency = (Currency)TypeDescriptor.GetConverter(typeof(Currency)).ConvertFromString(currency);
+            this.amount = Round(amount, Currency, MidpointRounding.ToEven);
         }
 #pragma warning restore CA1801 // Parameter context of method.ctor is never used.
 
@@ -71,7 +72,7 @@ namespace NodaMoney
         /// <param name="reader">The <see cref="XmlReader" /> stream from which the object is deserialized.</param>
         /// <exception cref="ArgumentNullException">The value of 'reader' cannot be null.</exception>
         /// <exception cref="SerializationException">The xml should have a content element with name Money.</exception>
-        public void ReadXml(XmlReader reader)
+        void IXmlSerializable.ReadXml(XmlReader reader)
         {
             if (reader == null)
                 throw new ArgumentNullException(nameof(reader));
@@ -79,14 +80,15 @@ namespace NodaMoney
             if (reader.MoveToContent() != XmlNodeType.Element)
                 throw new SerializationException("Couldn't find content element with name Money!");
 
-            Amount = decimal.Parse(reader["Amount"], CultureInfo.InvariantCulture);
-            Currency = (Currency)TypeDescriptor.GetConverter(typeof(Currency)).ConvertFromString(reader["Currency"]);
+            var amount = decimal.Parse(reader["Amount"], CultureInfo.InvariantCulture);
+            var currency = (Currency)TypeDescriptor.GetConverter(typeof(Currency)).ConvertFromString(reader["Currency"]);
+            Unsafe.AsRef(this) = new Money(amount, currency);
         }
 
         /// <summary>Converts an object into its XML representation.</summary>
         /// <param name="writer">The <see cref="XmlWriter" /> stream to which the object is serialized.</param>
         /// <exception cref="System.ArgumentNullException">The value of 'writer' cannot be null.</exception>
-        public void WriteXml(XmlWriter writer)
+        void IXmlSerializable.WriteXml(XmlWriter writer)
         {
             if (writer == null)
                 throw new ArgumentNullException(nameof(writer));
@@ -99,7 +101,7 @@ namespace NodaMoney
         /// <param name="info">The <see cref="SerializationInfo" /> to populate with data. </param>
         /// <param name="context">The destination (see <see cref="StreamingContext" />) for this serialization. </param>
         /// <exception cref="System.Security.SecurityException">The caller does not have the required permission. </exception>
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         {
             if (info == null)
                 throw new ArgumentNullException(nameof(info));

--- a/src/NodaMoney/Money.cs
+++ b/src/NodaMoney/Money.cs
@@ -12,8 +12,11 @@ namespace NodaMoney
     /// and ensure that two different currencies cannot be added or subtracted to each other.
     /// </remarks>
     [StructLayout(LayoutKind.Sequential)]
-    public partial struct Money : IEquatable<Money>
+    public readonly partial struct Money : IEquatable<Money>
     {
+        private readonly decimal amount;
+        private readonly Currency currency;
+
         /// <summary>Initializes a new instance of the <see cref="Money"/> struct, based on the current culture.</summary>
         /// <param name="amount">The Amount of money as <see langword="decimal"/>.</param>
         /// <remarks>The amount will be rounded to the number of decimal digits of the specified currency
@@ -82,8 +85,8 @@ namespace NodaMoney
         public Money(decimal amount, Currency currency, MidpointRounding rounding)
             : this()
         {
-            Currency = currency;
-            Amount = Round(amount, currency, rounding);
+            this.currency = currency ?? throw new ArgumentNullException(nameof(currency));
+            this.amount = Round(amount, currency, rounding);
         }
 
         // int, uint ([CLSCompliant(false)]) // auto-casting to decimal so not needed
@@ -220,10 +223,10 @@ namespace NodaMoney
         }
 
         /// <summary>Gets the amount of money.</summary>
-        public decimal Amount { get; private set; }
+        public readonly decimal Amount { get => amount; }
 
         /// <summary>Gets the <see cref="Currency"/> of the money.</summary>
-        public Currency Currency { get; private set; }
+        public readonly Currency Currency { get => currency; }
 
         /// <summary>Returns a value indicating whether two instances of <see cref="Money"/> are equal.</summary>
         /// <param name="left">A <see cref="Money"/> object on the left side.</param>

--- a/src/NodaMoney/NodaMoney.csproj
+++ b/src/NodaMoney/NodaMoney.csproj
@@ -7,9 +7,10 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>NodaMoney</PackageId>
     <PackageTags>Noda;Money;Currency;ExchangeRate</PackageTags>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0;netstandard2.1;net40;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0;netstandard2.1;net45;net461;net5</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
   </PropertyGroup>
  
   <ItemGroup>
@@ -36,13 +37,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
+      <Version>5.0.0</Version>
+    </PackageReference>
   </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-  
 </Project>

--- a/tests/NodaMoney.Tests/NodaMoney.Tests.csproj
+++ b/tests/NodaMoney.Tests/NodaMoney.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\NodaMoney.Serialization.JsonNet\NodaMoney.Serialization.JsonNet.csproj" />
     <ProjectReference Include="..\..\src\NodaMoney.Serialization.AspNet\NodaMoney.Serialization.AspNet.csproj" />
     <ProjectReference Include="..\..\src\NodaMoney\NodaMoney.csproj" />
   </ItemGroup>

--- a/tests/NodaMoney.Tests/Serialization/MoneySerializableSpec.cs
+++ b/tests/NodaMoney.Tests/Serialization/MoneySerializableSpec.cs
@@ -9,16 +9,19 @@ using Newtonsoft.Json;
 using System.Diagnostics;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Collections.Generic;
+using NodaMoney.Serialization.JsonNet;
 
 namespace NodaMoney.Tests.Serialization
 {
     public class GivenIWantToDeserializeMoneyWithJsonNetSerializer
     {
+        private readonly JsonSerializerSettings settings = new JsonSerializerSettings().ConfigureForNodaMoney();
+
         [Theory]
         [ClassData(typeof(ValidJsonTestData))]
         public void WhenDeserializing_ThenThisShouldSucceed(string json, Money expected)
         {
-            var clone = JsonConvert.DeserializeObject<Money>(json);
+            var clone = JsonConvert.DeserializeObject<Money>(json, settings);
 
             clone.Should().Be(expected);
         }
@@ -27,16 +30,16 @@ namespace NodaMoney.Tests.Serialization
         [ClassData(typeof(InvalidJsonTestData))]
         public void WhenDeserializingWithInvalidJSON_ThenThisShouldFail(string json)
         {
-            Action action = () => JsonConvert.DeserializeObject<Money>(json);
+            Action action = () => JsonConvert.DeserializeObject<Money>(json, settings);
 
-            action.Should().Throw<SerializationException>().WithMessage("Member '*");
+            action.Should().Throw<JsonSerializationException>();
         }
 
         [Theory]
         [ClassData(typeof(NestedJsonTestData))]
         public void WhenDeserializingWithNested_ThenThisShouldSucceed(string json, Order expected)
         {
-            var clone = JsonConvert.DeserializeObject<Order>(json);
+            var clone = JsonConvert.DeserializeObject<Order>(json, settings);
 
             clone.Should().BeEquivalentTo(expected);
             clone.Discount.Should().BeNull();
@@ -45,6 +48,8 @@ namespace NodaMoney.Tests.Serialization
 
     public class GivenIWantToSerializeMoneyWithJsonNetSerializer
     {
+        private readonly JsonSerializerSettings settings = new JsonSerializerSettings().ConfigureForNodaMoney();
+
         public static IEnumerable<object[]> TestData => new[]
         {
                 new object[] { new Money(765.4321m, Currency.FromCode("JPY")) },
@@ -68,9 +73,9 @@ namespace NodaMoney.Tests.Serialization
         [MemberData(nameof(TestData))]
         public void WhenSerializingMoney_ThenThisShouldSucceed(Money money)
         {
-            string json = JsonConvert.SerializeObject(money);
+            string json = JsonConvert.SerializeObject(money, settings);
             // Console.WriteLine(json);
-            var clone = JsonConvert.DeserializeObject<Money>(json);
+            var clone = JsonConvert.DeserializeObject<Money>(json, settings);
 
             clone.Should().Be(money);
         }
@@ -88,7 +93,7 @@ namespace NodaMoney.Tests.Serialization
 
             string json = JsonConvert.SerializeObject(order);
             // Console.WriteLine(json);
-            var clone = JsonConvert.DeserializeObject<Order>(json);
+            var clone = JsonConvert.DeserializeObject<Order>(json, settings);
 
             clone.Should().BeEquivalentTo(order);
         }


### PR DESCRIPTION
Inspired by the comment in issue #83, which makes a lot of sense. Currency is not similar to a value type.  

Also turned Money in a readonly struct, and custom JSON serialization support was needed as a result.

