### PR TITLE
Fixed issues with Swiss Francs

### DIFF
--- a/src/NodaMoney/Currency.cs
+++ b/src/NodaMoney/Currency.cs
@@ -252,6 +252,12 @@ namespace NodaMoney
         /// <returns>An <see cref="IEnumerable{Currency}"/> of all registered currencies.</returns>
         public static IEnumerable<Currency> GetAllCurrencies() => Registry.GetAllCurrencies();
 
+        /// <summary>Gets all registered currencies with a given symbol.</summary>
+        /// <param name="symbol">A currency symbol, like € or $.</param>
+        /// <returns>Returns all registered <see cref="Currency"/> instances with the given <paramref name="symbol"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">The value of 'symbol' cannot be null or empty.</exception>
+        public static IEnumerable<Currency> GetCurrencies(string symbol) => Registry.GetCurrencies(symbol);
+
         /// <summary>Returns a value indicating whether two specified instances of <see cref="Currency"/> represent the same value.</summary>
         /// <param name="left">The first <see cref="Currency"/> object.</param>
         /// <param name="right">The second <see cref="Currency"/> object.</param>

--- a/src/NodaMoney/CurrencyBuilder.cs
+++ b/src/NodaMoney/CurrencyBuilder.cs
@@ -110,7 +110,7 @@ namespace NodaMoney
         public Currency Register()
         {
             Currency currency = Build();
-            if (!Currency.Registry.TryAdd(Code, Namespace, currency))
+            if (!Currency.Registry.TryAdd(Namespace, currency))
                 throw new InvalidOperationException("The custom currency is already registered.");
 
             return currency;

--- a/src/NodaMoney/CurrencySymbolParser.cs
+++ b/src/NodaMoney/CurrencySymbolParser.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace NodaMoney
+{
+    /// <summary>Represents Money, an amount defined in a specific Currency.</summary>
+    public static class CurrencySymbolParser
+    {
+        private const int SuffixSymbolGroupIndex = 4;
+        private const int PrefixSymbolGroupIndex = 5;
+
+        private static readonly Regex CurrencySymbolMatcher = new Regex(@"^\(?\s*(([-+\d](.*\d)?)\s*([^-+\d\s]+)|([^-+\d\s]+)\s*([-+\d](.*\d)?))\s*\)?$");
+
+        /// <summary>Extracts the currency symbol from a given money value.</summary>
+        /// <param name="moneyValue">The string representation of the money value to parse.</param>
+        /// <returns>Returns the currency symbol extracted from the specified <paramref name="moneyValue"/>,
+        /// or <see cref="string.Empty"/> if no curreny symbol was found.</returns>
+        /// <exception cref="System.ArgumentNullException">The <i>moneyValue</i> is <b>null</b> or empty.</exception>
+        public static string Parse(string moneyValue)
+        {
+            if (string.IsNullOrWhiteSpace(moneyValue))
+                throw new ArgumentNullException(nameof(moneyValue));
+
+            var match = CurrencySymbolMatcher.Match(moneyValue);
+            string symbol;
+            if (match.Success)
+            {
+                var suffixSymbol = match.Groups[SuffixSymbolGroupIndex].Value;
+                var prefixSymbol = match.Groups[PrefixSymbolGroupIndex].Value;
+                symbol = suffixSymbol.Length == 0
+                    ? prefixSymbol
+                    : prefixSymbol.Length == 0 ? suffixSymbol : string.Empty;
+            }
+            else
+            {
+                symbol = string.Empty;
+            }
+
+            return symbol;
+        }
+    }
+}

--- a/tests/NodaMoney.Tests/CurrencySpec.cs
+++ b/tests/NodaMoney.Tests/CurrencySpec.cs
@@ -10,6 +10,7 @@ using System.Xml.Serialization;
 using System.Xml.Linq;
 using System.Threading.Tasks;
 using System.Net;
+using NodaMoney.Tests.Helpers;
 
 namespace NodaMoney.Tests.CurrencySpec
 {
@@ -91,7 +92,7 @@ namespace NodaMoney.Tests.CurrencySpec
             }
         }
     }
-    
+
     public class GivenIWantCurrencyFromIsoCode
     {
         [Fact]
@@ -176,7 +177,7 @@ namespace NodaMoney.Tests.CurrencySpec
         [Fact]
         public void WhenUsingCultureInfo_ThenCreatingShouldSucceed()
         {
-            var currency = Currency.FromCulture(CultureInfo.CreateSpecificCulture("nl-NL"));
+            var currency = Currency.FromCulture(CultureInfo.CreateSpecificCulture(CultureNames.NetherlandsDutch));
 
             currency.Should().NotBeNull();
             currency.Symbol.Should().Be("€");
@@ -203,7 +204,7 @@ namespace NodaMoney.Tests.CurrencySpec
         [Fact]
         public void WhenUsingCultureName_ThenCreatingShouldSucceed()
         {
-            var currency = Currency.FromRegion("nl-NL");
+            var currency = Currency.FromRegion(CultureNames.NetherlandsDutch);
 
             currency.Should().NotBeNull();
             currency.Symbol.Should().Be("€");
@@ -374,7 +375,7 @@ namespace NodaMoney.Tests.CurrencySpec
         }
     }
 
-    public class GivenIWantToSerializeCurrencyWitXmlSerializer
+    public class GivenIWantToSerializeCurrencyWithXmlSerializer
     {
         private Currency yen = Currency.FromCode("JPY");
 

--- a/tests/NodaMoney.Tests/CurrencySymbolParserSpec.cs
+++ b/tests/NodaMoney.Tests/CurrencySymbolParserSpec.cs
@@ -1,0 +1,66 @@
+﻿using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace NodaMoney.Tests.CurrencySpec
+{
+    public class GivenIWantToParseAllCurrencySymbols
+    {
+        [Fact]
+        public void WhenParsingCurrencySymbol_ThenCurrencySymbolShouldBeParsed()
+        {
+            foreach (var currencySymbol in Currency.GetAllCurrencies()
+                .Select(currency => currency.Symbol)
+                .Distinct())
+            {
+                var symbol = CurrencySymbolParser.Parse("1" + currencySymbol);
+                symbol.Should().NotBeNullOrEmpty();
+                symbol.Should().Be(currencySymbol);
+            }
+        }
+
+        [Fact]
+        public void WhenParsingCurrencyCodes_ThenCurrencyCodeShouldBeParsed()
+        {
+            foreach (var currencyCode in Currency.GetAllCurrencies()
+                .Select(currency => currency.Code)
+                .Distinct())
+            {
+                var code = CurrencySymbolParser.Parse("1" + currencyCode);
+                code.Should().NotBeNullOrEmpty();
+                code.Should().Be(currencyCode);
+            }
+        }
+
+        [Fact(Skip = "For debugging.")]
+        public void WhenAskingForCodeAndSymbol_ThenSomeCharactersUnfortunatelyAreNumeric()
+        {
+            var currencyCodeAndSymbolCharacters = Currency.GetAllCurrencies()
+                .SelectMany(currency => currency.Code + currency.Symbol)
+                .Distinct();
+
+            var numericCodeAndSymbolCharacters = currencyCodeAndSymbolCharacters
+                .Where(character => !IsNotNumericCharacter(character))
+                .ToList();
+
+            numericCodeAndSymbolCharacters.Should().NotBeEmpty();
+            numericCodeAndSymbolCharacters.Should().Contain('.');
+        }
+
+
+        /// <summary>
+        /// Indicates whether a given character is considered part of the currency code or symbol.
+        /// </summary>
+        /// <param name="character">The character to examine.</param>
+        /// <returns>
+        /// Returns <see langword="true"/> if the specified <paramref name="character"/>
+        /// is considered part of the curreny code or symbol;
+        /// otherwise, returns <see langword="false"/>.
+        /// </returns>
+        internal static bool IsNotNumericCharacter(char character) =>
+            !char.IsDigit(character) &&
+            !char.IsWhiteSpace(character) &&
+            !char.IsPunctuation(character) &&
+            !char.IsSeparator(character);
+    }
+}

--- a/tests/NodaMoney.Tests/ExchangeRateSpec.cs
+++ b/tests/NodaMoney.Tests/ExchangeRateSpec.cs
@@ -224,13 +224,13 @@ namespace NodaMoney.Tests.ExchangeRateSpec
     {
         ExchangeRate fx = new ExchangeRate(Currency.FromCode("EUR"), Currency.FromCode("USD"), 1.2524);
 
-        [Fact, UseCulture("en-US")]
+        [Fact, UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenShowingExchangeRateInAmerica_ThenReturnCurrencyPairWithDot()
         {
             fx.ToString().Should().Be("EUR/USD 1.2524");
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenShowingExchangeRateInNetherlands_ThenReturnCurrencyPairWithComma()
         {
             fx.ToString().Should().Be("EUR/USD 1,2524");
@@ -239,7 +239,7 @@ namespace NodaMoney.Tests.ExchangeRateSpec
 
     public class GivenIWantToParseACurrencyPair
     {
-        [Fact, UseCulture("en-US")]
+        [Fact, UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenCurrencyPairInUsCulture_ThenParsingShouldSucceed()
         {
             var fx1 = ExchangeRate.Parse("EUR/USD 1.2591");
@@ -255,7 +255,7 @@ namespace NodaMoney.Tests.ExchangeRateSpec
             fx2.Value.Should().Be(1.2591M);
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenCurrencyPairInNlCulture_ThenParsingShouldSucceed()
         {
             var fx1 = ExchangeRate.Parse("EUR/USD 1,2591");
@@ -279,7 +279,7 @@ namespace NodaMoney.Tests.ExchangeRateSpec
             action.Should().Throw<FormatException>();
         }
 
-        [Fact, UseCulture("en-US")]
+        [Fact, UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenCurrencyPairHasSameCurrencies_ThenThrowException()
         {
             Action action = () => ExchangeRate.Parse("EUR/EUR 1.2591");
@@ -306,7 +306,7 @@ namespace NodaMoney.Tests.ExchangeRateSpec
 
     public class GivenIWantToTryParseACurrencyPair
     {
-        [Fact, UseCulture("en-US")]
+        [Fact, UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenCurrencyPairInUsCulture_ThenParsingShouldSucceed()
         {
             ExchangeRate fx1;
@@ -326,7 +326,7 @@ namespace NodaMoney.Tests.ExchangeRateSpec
             fx2.Value.Should().Be(1.2591M);
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenCurrencyPairInNlCulture_ThenParsingShouldSucceed()
         {
             ExchangeRate fx1;
@@ -358,7 +358,7 @@ namespace NodaMoney.Tests.ExchangeRateSpec
             fx.Value.Should().Be(0M);
         }
 
-        [Fact, UseCulture("en-US")]
+        [Fact, UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenCurrencyPairHasSameCurrencies_ThenParsingFails()
         {
             ExchangeRate fx;

--- a/tests/NodaMoney.Tests/Helpers/CultureNames.cs
+++ b/tests/NodaMoney.Tests/Helpers/CultureNames.cs
@@ -1,0 +1,27 @@
+﻿using System.Globalization;
+
+namespace NodaMoney.Tests.Helpers
+{
+    /// <summary>Names for <see cref="CultureInfo" /> instances.</summary>
+    public static class CultureNames
+    {
+        // '.': CurrencyDecimalSeparator
+        // ',': CurrencyGroupSeparator
+        public const string Invariant = "";
+
+        public const string UnitedStatesEnglish = "en-US";
+        public const string NetherlandsDutch = "nl-NL";
+        public const string BelgiumDutch = "nl-BE";
+        public const string BelgiumFrench = "fr-BE";
+        public const string BrazilPortuguese = "pt-BR";
+        public const string JapanJapanese = "ja-JP";
+        public const string ArgentinaSpanish = "es-AR";
+        public const string ChinaMainlandChinese = "zh-CN";
+
+        // '\u00A0': Unicode Character 'NO-BREAK SPACE' (U+00A0), used as CurrencyGroupSeparator in fr-FR
+        public const string FranceFrench = "fr-FR";
+
+        // '’': Unicode Character 'RIGHT SINGLE QUOTATION MARK' (U+2019), used as CurrencyGroupSeparator in de-CH
+        public const string SwitzerlandGerman = "de-CH";
+    }
+}

--- a/tests/NodaMoney.Tests/MoneyBinaryOperatorsSpec.cs
+++ b/tests/NodaMoney.Tests/MoneyBinaryOperatorsSpec.cs
@@ -75,7 +75,7 @@ namespace NodaMoney.Tests.MoneyBinaryOperatorsSpec
         }
 
         [Theory, MemberData(nameof(TestData))]
-        [UseCulture("en-us")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenUsingAddtionOperatorWithDecimal_ThenMoneyShouldBeAdded(decimal value1, decimal value2, decimal expected)
         {
             var money1 = new Money(value1, "EUR");
@@ -90,7 +90,7 @@ namespace NodaMoney.Tests.MoneyBinaryOperatorsSpec
         }
 
         [Theory, MemberData(nameof(TestData))]
-        [UseCulture("en-us")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenUsingAdditionMethodWithDecimal_ThenMoneyShouldBeAdded(decimal value1, decimal value2, decimal expected)
         {
             var money1 = new Money(value1, "EUR");
@@ -102,7 +102,7 @@ namespace NodaMoney.Tests.MoneyBinaryOperatorsSpec
         }
 
         [Theory, MemberData(nameof(TestData))]
-        [UseCulture("en-us")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenUsingSubstractionOperatorWithDecimal_ThenMoneyShouldBeAdded(decimal expected, decimal value2, decimal value1)
         {
             var money1 = new Money(value1, "EUR");
@@ -117,7 +117,7 @@ namespace NodaMoney.Tests.MoneyBinaryOperatorsSpec
         }
 
         [Theory, MemberData(nameof(TestData))]
-        [UseCulture("en-us")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenUsingSubstractionMethodWithDecimal_ThenMoneyShouldBeSubtracted(decimal expected, decimal value2, decimal value1)
         {
             var money1 = new Money(value1, "EUR");

--- a/tests/NodaMoney.Tests/MoneyFormattableSpec.cs
+++ b/tests/NodaMoney.Tests/MoneyFormattableSpec.cs
@@ -9,42 +9,70 @@ namespace NodaMoney.Tests.MoneyFormattableSpec
 {
     public class GivenIWantMoneyAsString
     {
-        private Money _yen = new Money(765.4321m, Currency.FromCode("JPY"));
-        private Money _euro = new Money(765.4321m, Currency.FromCode("EUR"));
-        private Money _dollar = new Money(765.4321m, Currency.FromCode("USD"));
-        private Money _dinar = new Money(765.4321m, Currency.FromCode("BHD"));
+        private Money _yen = new Money(-98765.4321m, Currency.FromCode("JPY"));
+        private Money _euro = new Money(-98765.4321m, Currency.FromCode("EUR"));
+        private Money _dollar = new Money(-98765.4321m, Currency.FromCode("USD"));
+        private Money _dinar = new Money(-98765.4321m, Currency.FromCode("BHD"));
+        private Money _swissFranc = new Money(-98765.4321m, Currency.FromCode("CHF"));
 
         [Fact]
-        [UseCulture("en-US")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenToStringAndCurrentCultureUS_ThenDecimalsFollowsCurrencyAndAmountFollowsCurrentCultureUS()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
-            _yen.ToString().Should().Be("¥765");
-            _euro.ToString().Should().Be("€765.43");
-            _dollar.ToString().Should().Be("$765.43");
-            _dinar.ToString().Should().Be("BD765.432");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.UnitedStatesEnglish);
+            _yen.ToString().Should().Be("(¥98,765)");
+            _euro.ToString().Should().Be("(€98,765.43)");
+            _dollar.ToString().Should().Be("($98,765.43)");
+            _dinar.ToString().Should().Be("(BD98,765.432)");
+            _swissFranc.ToString().Should().Be("(CHF98,765.43)");
         }
 
         [Fact]
-        [UseCulture("nl-NL")]
+        [UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenToStringAndCurrentCultureNL_ThenDecimalsFollowsCurrencyAndAmountFollowsCurrentCultureNL()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("nl-NL");
-            _yen.ToString().Should().Be("¥ 765");
-            _euro.ToString().Should().Be("€ 765,43");
-            _dollar.ToString().Should().Be("$ 765,43");
-            _dinar.ToString().Should().Be("BD 765,432");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.NetherlandsDutch);
+            _yen.ToString().Should().Be("¥ -98.765");
+            _euro.ToString().Should().Be("€ -98.765,43");
+            _dollar.ToString().Should().Be("$ -98.765,43");
+            _dinar.ToString().Should().Be("BD -98.765,432");
+            _swissFranc.ToString().Should().Be("CHF -98.765,43");
         }
 
         [Fact]
-        [UseCulture("fr-FR")]
-        public void WhenToStringAndCurrentCultureFR_ThenDecimalsFollowsCurrencyAndAmountFollowsCurrentCultureFR()
+        [UseCulture(CultureNames.FranceFrench)]
+        public void WhenToStringAndCurrentCultureFR_ThenCurrencyFollowsDecimalsAndAmountFollowsCurrentCultureFR()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("fr-FR");
-            _yen.ToString().Should().Be("765 ¥");
-            _euro.ToString().Should().Be("765,43 €");
-            _dollar.ToString().Should().Be("765,43 $");
-            _dinar.ToString().Should().Be("765,432 BD");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.FranceFrench);
+            _yen.ToString().Should().Be("-98\u00a0765 ¥");
+            _euro.ToString().Should().Be("-98\u00a0765,43 €");
+            _dollar.ToString().Should().Be("-98\u00a0765,43 $");
+            _dinar.ToString().Should().Be("-98\u00a0765,432 BD");
+            _swissFranc.ToString().Should().Be("-98\u00a0765,43 CHF");
+        }
+
+        [Fact]
+        [UseCulture(CultureNames.SwitzerlandGerman)]
+        public void WhenToStringAndCurrentCultureDeCH_ThenDecimalsFollowsCurrencyAndAmountFollowsCurrentCultureFR()
+        {
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.SwitzerlandGerman);
+            _yen.ToString().Should().Be("¥-98’765");
+            _euro.ToString().Should().Be("€-98’765.43");
+            _dollar.ToString().Should().Be("$-98’765.43");
+            _dinar.ToString().Should().Be("BD-98’765.432");
+            _swissFranc.ToString().Should().Be("CHF-98’765.43");
+        }
+
+        [Fact]
+        [UseCulture(CultureNames.Invariant)]
+        public void WhenToStringAndCurrentCultureInvariant_ThenCurrencyFollowsDecimalsAndAmountFollowsInvariantCulture()
+        {
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.Invariant);
+            _yen.ToString().Should().Be("(¥98,765)");
+            _euro.ToString().Should().Be("(€98,765.43)");
+            _dollar.ToString().Should().Be("($98,765.43)");
+            _dinar.ToString().Should().Be("(BD98,765.432)");
+            _swissFranc.ToString().Should().Be("(CHF98,765.43)");
         }
 
         [Fact]
@@ -56,29 +84,31 @@ namespace NodaMoney.Tests.MoneyFormattableSpec
         }
 
         [Fact]
-        [UseCulture("en-US")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenGivenCultureInfo_ThenDecimalsFollowsCurrencyAndAmountFollowsGivenCultureInfo()
         {
-            var ci = new CultureInfo("nl-NL");
+            var ci = new CultureInfo(CultureNames.NetherlandsDutch);
 
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
-            _yen.ToString(ci).Should().Be("¥ 765");
-            _euro.ToString(ci).Should().Be("€ 765,43");
-            _dollar.ToString(ci).Should().Be("$ 765,43");
-            _dinar.ToString(ci).Should().Be("BD 765,432");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.UnitedStatesEnglish);
+            _yen.ToString(ci).Should().Be("¥ -98.765");
+            _euro.ToString(ci).Should().Be("€ -98.765,43");
+            _dollar.ToString(ci).Should().Be("$ -98.765,43");
+            _dinar.ToString(ci).Should().Be("BD -98.765,432");
+            _swissFranc.ToString(ci).Should().Be("CHF -98.765,43");
         }
 
         [Fact]
-        [UseCulture("en-US")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenGivenNumberFormat_ThenDecimalsFollowsCurrencyAndAmountFollowsGivenNumberFormat()
         {
-            var nfi = new CultureInfo("nl-NL").NumberFormat;
+            var nfi = new CultureInfo(CultureNames.NetherlandsDutch).NumberFormat;
 
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
-            _yen.ToString(nfi).Should().Be("¥ 765");
-            _euro.ToString(nfi).Should().Be("€ 765,43");
-            _dollar.ToString(nfi).Should().Be("$ 765,43");
-            _dinar.ToString(nfi).Should().Be("BD 765,432");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.UnitedStatesEnglish);
+            _yen.ToString(nfi).Should().Be("¥ -98.765");
+            _euro.ToString(nfi).Should().Be("€ -98.765,43");
+            _dollar.ToString(nfi).Should().Be("$ -98.765,43");
+            _dinar.ToString(nfi).Should().Be("BD -98.765,432");
+            _swissFranc.ToString(nfi).Should().Be("CHF -98.765,43");
         }
 
         [Fact]
@@ -119,8 +149,8 @@ namespace NodaMoney.Tests.MoneyFormattableSpec
         public void WhenUsingToStringWithGFormatWithCulture_ThenReturnsTheSameAsTheDefaultFormatWithThatCulture()
         {
             _yen.ToString("G", CultureInfo.InvariantCulture).Should().Be(_yen.ToString(null, CultureInfo.InvariantCulture));
-            _yen.ToString("G", CultureInfo.GetCultureInfo("nl-NL")).Should().Be(_yen.ToString(null, CultureInfo.GetCultureInfo("nl-NL")));
-            _yen.ToString("G", CultureInfo.GetCultureInfo("fr-FR")).Should().Be(_yen.ToString(null, CultureInfo.GetCultureInfo("fr-FR")));
+            _yen.ToString("G", CultureInfo.GetCultureInfo(CultureNames.NetherlandsDutch)).Should().Be(_yen.ToString(null, CultureInfo.GetCultureInfo(CultureNames.NetherlandsDutch)));
+            _yen.ToString("G", CultureInfo.GetCultureInfo(CultureNames.FranceFrench)).Should().Be(_yen.ToString(null, CultureInfo.GetCultureInfo(CultureNames.FranceFrench)));
         }
 
         [Fact]
@@ -140,93 +170,102 @@ namespace NodaMoney.Tests.MoneyFormattableSpec
         private Money _euro = new Money(765.4321m, Currency.FromCode("EUR"));
         private Money _dollar = new Money(765.4321m, Currency.FromCode("USD"));
         private Money _dinar = new Money(765.4321m, Currency.FromCode("BHD"));
+        private Money _swissFranc = new Money(765.4321m, Currency.FromCode("CHF"));
 
         [Fact]
-        [UseCulture("en-US")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenCurrentCultureUS_ThenDecimalsFollowsCurrencyAndAmountFollowsCurrentCultureNL()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.UnitedStatesEnglish);
             _yen.ToString("C").Should().Be("¥765");
             _euro.ToString("C").Should().Be("€765.43");
             _dollar.ToString("C").Should().Be("$765.43");
             _dinar.ToString("C").Should().Be("BD765.432");
+            _swissFranc.ToString("C").Should().Be("CHF765.43");
         }
 
         [Fact]
-        [UseCulture("nl-NL")]
+        [UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenCurrentCultureNL_ThenDecimalsFollowsCurrencyAndAmountFollowsCurrentCultureNL()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("nl-NL");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.NetherlandsDutch);
             _yen.ToString("C").Should().Be("¥ 765");
             _euro.ToString("C").Should().Be("€ 765,43");
             _dollar.ToString("C").Should().Be("$ 765,43");
             _dinar.ToString("C").Should().Be("BD 765,432");
+            _swissFranc.ToString("C").Should().Be("CHF 765,43");
         }
 
         [Fact]
-        [UseCulture("fr-FR")]
+        [UseCulture(CultureNames.FranceFrench)]
         public void WhenCurrentCultureFR_ThenDecimalsFollowsCurrencyAndAmountFollowsCurrentCultureFR()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("fr-FR");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.FranceFrench);
             _yen.ToString("C").Should().Be("765 ¥");
             _euro.ToString("C").Should().Be("765,43 €");
             _dollar.ToString("C").Should().Be("765,43 $");
             _dinar.ToString("C").Should().Be("765,432 BD");
+            _swissFranc.ToString("C").Should().Be("765,43 CHF");
         }
 
         [Fact]
-        [UseCulture("en-US")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenZeroDecimals_ThenThisShouldSucceed()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.UnitedStatesEnglish);
             _yen.ToString("C0").Should().Be("¥765");
             _euro.ToString("C0").Should().Be("€765");
             _dollar.ToString("C0").Should().Be("$765");
             _dinar.ToString("C0").Should().Be("BD765");
+            _swissFranc.ToString("C0").Should().Be("CHF765");
         }
 
         [Fact]
-        [UseCulture("en-US")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenOneDecimals_ThenThisShouldSucceed()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.UnitedStatesEnglish);
             _yen.ToString("C1").Should().Be("¥765.0");
             _euro.ToString("C1").Should().Be("€765.4");
             _dollar.ToString("C1").Should().Be("$765.4");
             _dinar.ToString("C1").Should().Be("BD765.4");
+            _swissFranc.ToString("C1").Should().Be("CHF765.4");
         }
 
         [Fact]
-        [UseCulture("en-US")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenTwoDecimals_ThenThisShouldSucceed()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.UnitedStatesEnglish);
             _yen.ToString("C2").Should().Be("¥765.00");
             _euro.ToString("C2").Should().Be("€765.43");
             _dollar.ToString("C2").Should().Be("$765.43");
             _dinar.ToString("C2").Should().Be("BD765.43");
+            _swissFranc.ToString("C2").Should().Be("CHF765.43");
         }
 
         [Fact]
-        [UseCulture("en-US")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenThreeDecimals_ThenThisShouldSucceed()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.UnitedStatesEnglish);
             _yen.ToString("C3").Should().Be("¥765.000");
             _euro.ToString("C3").Should().Be("€765.430");
             _dollar.ToString("C3").Should().Be("$765.430");
             _dinar.ToString("C3").Should().Be("BD765.432");
+            _swissFranc.ToString("C3").Should().Be("CHF765.430");
         }
 
         [Fact]
-        [UseCulture("en-US")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenFourDecimals_ThenThisShouldSucceed()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.UnitedStatesEnglish);
             _yen.ToString("C4").Should().Be("¥765.0000");
             _euro.ToString("C4").Should().Be("€765.4300");
             _dollar.ToString("C4").Should().Be("$765.4300");
             _dinar.ToString("C4").Should().Be("BD765.4320");
+            _swissFranc.ToString("C4").Should().Be("CHF765.4300");
         }
     }
 
@@ -236,93 +275,102 @@ namespace NodaMoney.Tests.MoneyFormattableSpec
         private Money _euro = new Money(765.4321m, Currency.FromCode("EUR"));
         private Money _dollar = new Money(765.4321m, Currency.FromCode("USD"));
         private Money _dinar = new Money(765.4321m, Currency.FromCode("BHD"));
+        private Money _swissFranc = new Money(765.4321m, Currency.FromCode("CHF"));
 
         [Fact]
-        [UseCulture("en-US")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenCurrentCultureUS_ThenDecimalsFollowsCurrencyAndAmountFollowsCurrentCultureNL()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.UnitedStatesEnglish);
             _yen.ToString("I").Should().Be("JPY 765");
             _euro.ToString("I").Should().Be("EUR 765.43");
             _dollar.ToString("I").Should().Be("USD 765.43");
             _dinar.ToString("I").Should().Be("BHD 765.432");
+            _swissFranc.ToString("I").Should().Be("CHF 765.43");
         }
 
         [Fact]
-        [UseCulture("nl-NL")]
+        [UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenCurrentCultureNL_ThenDecimalsFollowsCurrencyAndAmountFollowsCurrentCultureNL()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("nl-NL");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.NetherlandsDutch);
             _yen.ToString("I").Should().Be("JPY 765");
             _euro.ToString("I").Should().Be("EUR 765,43");
             _dollar.ToString("I").Should().Be("USD 765,43");
             _dinar.ToString("I").Should().Be("BHD 765,432");
+            _swissFranc.ToString("I").Should().Be("CHF 765,43");
         }
-        
+
         [Fact]
-        [UseCulture("fr-FR")]
+        [UseCulture(CultureNames.FranceFrench)]
         public void WhenCurrentCultureFR_ThenDecimalsFollowsCurrencyAndAmountFollowsCurrentCultureFR()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("fr-FR");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.FranceFrench);
             _yen.ToString("I").Should().Be("765 JPY");
             _euro.ToString("I").Should().Be("765,43 EUR");
             _dollar.ToString("I").Should().Be("765,43 USD");
             _dinar.ToString("I").Should().Be("765,432 BHD");
+            _swissFranc.ToString("I").Should().Be("765,43 CHF");
         }
 
         [Fact]
-        [UseCulture("en-US")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenZeroDecimals_ThenThisShouldSucceed()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.UnitedStatesEnglish);
             _yen.ToString("I0").Should().Be("JPY 765");
             _euro.ToString("I0").Should().Be("EUR 765");
             _dollar.ToString("I0").Should().Be("USD 765");
             _dinar.ToString("I0").Should().Be("BHD 765");
+            _swissFranc.ToString("I0").Should().Be("CHF 765");
         }
 
         [Fact]
-        [UseCulture("en-US")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenOneDecimals_ThenThisShouldSucceed()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.UnitedStatesEnglish);
             _yen.ToString("I1").Should().Be("JPY 765.0");
             _euro.ToString("I1").Should().Be("EUR 765.4");
             _dollar.ToString("I1").Should().Be("USD 765.4");
             _dinar.ToString("I1").Should().Be("BHD 765.4");
+            _swissFranc.ToString("I1").Should().Be("CHF 765.4");
         }
 
         [Fact]
-        [UseCulture("en-US")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenTwoDecimals_ThenThisShouldSucceed()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.UnitedStatesEnglish);
             _yen.ToString("I2").Should().Be("JPY 765.00");
             _euro.ToString("I2").Should().Be("EUR 765.43");
             _dollar.ToString("I2").Should().Be("USD 765.43");
             _dinar.ToString("I2").Should().Be("BHD 765.43");
+            _swissFranc.ToString("I2").Should().Be("CHF 765.43");
         }
 
         [Fact]
-        [UseCulture("en-US")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenThreeDecimals_ThenThisShouldSucceed()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.UnitedStatesEnglish);
             _yen.ToString("I3").Should().Be("JPY 765.000");
             _euro.ToString("I3").Should().Be("EUR 765.430");
             _dollar.ToString("I3").Should().Be("USD 765.430");
             _dinar.ToString("I3").Should().Be("BHD 765.432");
+            _swissFranc.ToString("I3").Should().Be("CHF 765.430");
         }
 
         [Fact]
-        [UseCulture("en-US")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenFourDecimals_ThenThisShouldSucceed()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.UnitedStatesEnglish);
             _yen.ToString("I4").Should().Be("JPY 765.0000");
             _euro.ToString("I4").Should().Be("EUR 765.4300");
             _dollar.ToString("I4").Should().Be("USD 765.4300");
             _dinar.ToString("I4").Should().Be("BHD 765.4320");
+            _swissFranc.ToString("I4").Should().Be("CHF 765.4300");
         }
     }
 
@@ -332,82 +380,90 @@ namespace NodaMoney.Tests.MoneyFormattableSpec
         private Money _euro = new Money(765.4321m, Currency.FromCode("EUR"));
         private Money _dollar = new Money(765.4321m, Currency.FromCode("USD"));
         private Money _dinar = new Money(765.4321m, Currency.FromCode("BHD"));
+        private Money _swissFranc = new Money(765.4321m, Currency.FromCode("CHF"));
 
         [Fact]
-        [UseCulture("pt-BR")]
+        [UseCulture(CultureNames.BrazilPortuguese)]
         public void WhenCurrentCulturePTBR_ThenDecimalsFollowsCurrencyAndAmountFollowsCurrentCulturePtBRAndCurrencyNameIsInEnglish()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("pt-BR");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.BrazilPortuguese);
             _yen.ToString("F").Should().Be("765 Japanese yen");
             _euro.ToString("F").Should().Be("765,43 Euro");
             _dollar.ToString("F").Should().Be("765,43 United States dollar");
             _dinar.ToString("F").Should().Be("765,432 Bahraini dinar");
+            _swissFranc.ToString("F").Should().Be("765,43 Swiss franc");
         }
 
         [Fact]
-        [UseCulture("en-US")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenCurrentCultureEnUS_ThenDecimalsFollowsCurrencyAndAmountFollowsCurrentCultureEnUSAndCurrencyNameIsInEnglish()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.UnitedStatesEnglish);
             _yen.ToString("F").Should().Be("765 Japanese yen");
             _euro.ToString("F").Should().Be("765.43 Euro");
             _dollar.ToString("F").Should().Be("765.43 United States dollar");
             _dinar.ToString("F").Should().Be("765.432 Bahraini dinar");
+            _swissFranc.ToString("F").Should().Be("765.43 Swiss franc");
         }
 
         [Fact]
-        [UseCulture("en-US")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenZeroDecimals_ThenThisShouldSucceed()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.UnitedStatesEnglish);
             _yen.ToString("F0").Should().Be("765 Japanese yen");
             _euro.ToString("F0").Should().Be("765 Euro");
             _dollar.ToString("F0").Should().Be("765 United States dollar");
             _dinar.ToString("F0").Should().Be("765 Bahraini dinar");
+            _swissFranc.ToString("F0").Should().Be("765 Swiss franc");
         }
 
         [Fact]
-        [UseCulture("en-US")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenOneDecimals_ThenThisShouldSucceed()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.UnitedStatesEnglish);
             _yen.ToString("F1").Should().Be("765.0 Japanese yen");
             _euro.ToString("F1").Should().Be("765.4 Euro");
             _dollar.ToString("F1").Should().Be("765.4 United States dollar");
             _dinar.ToString("F1").Should().Be("765.4 Bahraini dinar");
+            _swissFranc.ToString("F1").Should().Be("765.4 Swiss franc");
         }
 
         [Fact]
-        [UseCulture("en-US")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenTwoDecimals_ThenThisShouldSucceed()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.UnitedStatesEnglish);
             _yen.ToString("F2").Should().Be("765.00 Japanese yen");
             _euro.ToString("F2").Should().Be("765.43 Euro");
             _dollar.ToString("F2").Should().Be("765.43 United States dollar");
             _dinar.ToString("F2").Should().Be("765.43 Bahraini dinar");
+            _swissFranc.ToString("F2").Should().Be("765.43 Swiss franc");
         }
 
         [Fact]
-        [UseCulture("en-US")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenThreeDecimals_ThenThisShouldSucceed()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.UnitedStatesEnglish);
             _yen.ToString("F3").Should().Be("765.000 Japanese yen");
             _euro.ToString("F3").Should().Be("765.430 Euro");
             _dollar.ToString("F3").Should().Be("765.430 United States dollar");
             _dinar.ToString("F3").Should().Be("765.432 Bahraini dinar");
+            _swissFranc.ToString("F3").Should().Be("765.430 Swiss franc");
         }
 
         [Fact]
-        [UseCulture("en-US")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenFourDecimals_ThenThisShouldSucceed()
         {
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.UnitedStatesEnglish);
             _yen.ToString("F4").Should().Be("765.0000 Japanese yen");
             _euro.ToString("F4").Should().Be("765.4300 Euro");
             _dollar.ToString("F4").Should().Be("765.4300 United States dollar");
             _dinar.ToString("F4").Should().Be("765.4320 Bahraini dinar");
+            _swissFranc.ToString("F4").Should().Be("765.4300 Swiss franc");
         }
     }
 }

--- a/tests/NodaMoney.Tests/MoneyParsableSpec.cs
+++ b/tests/NodaMoney.Tests/MoneyParsableSpec.cs
@@ -1,6 +1,5 @@
-using System;
+ï»¿using System;
 using System.Globalization;
-using System.Threading;
 
 using FluentAssertions;
 using Xunit;
@@ -10,92 +9,112 @@ namespace NodaMoney.Tests.MoneyParsableSpec
 {
     public class GivenIWantToParseImplicitCurrency
     {
-        [Fact, UseCulture("nl-BE")]
+        [Fact, UseCulture(CultureNames.BelgiumDutch)]
         public void WhenInBelgiumDutchSpeaking_ThenThisShouldSucceed()
         {
-            var euro = Money.Parse("€ 765,43");
+            const string Value = "â‚¬ -98.765,43";
+            var money = Money.Parse(Value);
 
-            euro.Should().Be(new Money(765.43m, "EUR"));
+            money.Should().Be(new Money(-98765.43m, "EUR"));
         }
 
-        [Fact, UseCulture("fr-BE")]
+        [Fact, UseCulture(CultureNames.BelgiumFrench)]
         public void WhenInBelgiumFrenchSpeaking_ThenThisShouldSucceed()
         {
-            var euro = Money.Parse("765,43 €");
+            const string Value = "-98.765,43 â‚¬";
+            var money = Money.Parse(Value);
 
-            euro.Should().Be(new Money(765.43, "EUR"));
+            money.Should().Be(new Money(-98765.43, "EUR"));
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenParsingNumberWithoutCurrency_ThenThisUseCurrencyOfCurrentCulture()
         {
-            var euro = Money.Parse("765,43");
+            const string Value = "-98.765,43";
+            var money = Money.Parse(Value);
 
-            euro.Should().Be(new Money(765.43, "EUR"));
+            money.Should().Be(new Money(-98765.43, "EUR"));
         }
 
-        [Fact, UseCulture("ja-JP")]
+        [Fact, UseCulture(CultureNames.JapanJapanese)]
         public void WhenParsingYenYuanSymbolInJapan_ThenThisShouldReturnJapaneseYen()
         {
-            var yen = Money.Parse("¥ 765");
+            const string Value = "Â¥ -98,765";
+            var money = Money.Parse(Value);
 
-            yen.Should().Be(new Money(765m, "JPY"));
+            money.Should().Be(new Money(-98765m, "JPY"));
         }
 
-        [Fact, UseCulture("zh-CN")]
+        [Fact, UseCulture(CultureNames.ChinaMainlandChinese)]
         public void WhenParsingYenYuanSymbolInChina_ThenThisShouldReturnChineseYuan()
         {
-            var yuan = Money.Parse("¥ 765");
+            const string Value = "Â¥ -98,765";
+            var money = Money.Parse(Value);
 
-            yuan.Should().Be(new Money(765m, "CNY"));
+            money.Should().Be(new Money(-98765m, "CNY"));
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenParsingYenYuanInNetherlands_ThenThisShouldFail()
         {
-            // ¥ symbol is used for Japanese yen and Chinese yuan
-            Action action = () => Money.Parse("¥ 765");
+            // Â¥ symbol is used for Japanese money and Chinese money
+            const string Value = "Â¥ -98,765";
+            Action action = () => Money.Parse(Value);
 
-            action.Should().Throw<FormatException>().WithMessage("*multiple known currencies*");
+            action.Should().Throw<FormatException>().WithMessage("*Specify currency or culture explicitly*");
         }
 
-        [Fact, UseCulture("en-US")]
+        [Fact, UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenParsingDollarSymbolInUSA_ThenThisShouldReturnUSDollar()
         {
-            var dollar = Money.Parse("$765.43");
+            const string Value = "$-98,765.43";
+            var money = Money.Parse(Value);
 
-            dollar.Should().Be(new Money(765.43m, "USD"));
+            money.Should().Be(new Money(-98765.43m, "USD"));
         }
 
-        [Fact, UseCulture("es-AR")]
+        [Fact, UseCulture(CultureNames.ArgentinaSpanish)]
         public void WhenParsingDollarSymbolInArgentina_ThenThisShouldReturnArgentinePeso()
         {
-            var peso = Money.Parse("$765,43");
+            const string Value = "$-98.765,43";
+            var money = Money.Parse(Value);
 
-            peso.Should().Be(new Money(765.43m, "ARS"));
+            money.Should().Be(new Money(-98765.43m, "ARS"));
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenParsingDollarSymbolInNetherlands_ThenThisShouldFail()
         {
             // $ symbol is used for multiple currencies
-            Action action = () => Money.Parse("$ 765,43");
+            const string Value = "$ -98.765,43";
+            Action action = () => Money.Parse(Value);
 
-            action.Should().Throw<FormatException>().WithMessage("*multiple known currencies*");
+            action.Should().Throw<FormatException>().WithMessage("*Specify currency or culture explicitly*");
         }
 
-        [Fact, UseCulture("en-US")]
+        [Fact, UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenParsingEuroSymbolInUSA_ThenThisShouldReturnUSDollar()
         {
-            var euro = Money.Parse("€765.43");
+            const string Value = "â‚¬-98,765.43";
+            var money = Money.Parse(Value);
 
-            euro.Should().Be(new Money(765.43m, "EUR"));
+            money.Should().Be(new Money(-98765.43m, "EUR"));
+        }
+
+        [Fact, UseCulture(CultureNames.SwitzerlandGerman)]
+        public void WhenParsingChfSymbolInSwitzerlandGermanSpeaking_ThenThisShouldReturnSwissFranc()
+        {
+            const string Value = "-98â€™765.23 CHF";
+            var money = Money.Parse(Value);
+
+            money.Should().Be(new Money(-98765.23m, "CHF"));
         }
 
         [Fact]
         public void WhenValueIsNull_ThenThowExeception()
         {
-            Action action = () => Money.Parse(null);
+            const string Value = null;
+            Action action = () => Money.Parse(Value);
 
             action.Should().Throw<ArgumentNullException>();
         }
@@ -103,373 +122,470 @@ namespace NodaMoney.Tests.MoneyParsableSpec
         [Fact]
         public void WhenValueIsEmpty_ThenThowExeception()
         {
-            Action action = () => Money.Parse("");
+            const string Value = "";
+            Action action = () => Money.Parse(Value);
 
             action.Should().Throw<ArgumentNullException>();
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenCurrencyIsUnknown_ThenThowExeception()
         {
-            Action action = () => Money.Parse("XYZ 765,43");
+            const string Value = "XYZ -98.765,43";
+            Action action = () => Money.Parse(Value);
 
-            action.Should().Throw<FormatException>().WithMessage("*unknown currency*");
+            action.Should().Throw<FormatException>().WithMessage("*must be a known currency*");
         }
     }
 
     public class GivenIWantToParseExplicitCurrency
     {
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenParsingYenInNetherlands_ThenThisShouldSucceed()
         {
-            var yen = Money.Parse("¥ 765", Currency.FromCode("JPY"));
+            const string Value = "Â¥ -98.765";
+            var money = Money.Parse(Value, Currency.FromCode("JPY"));
 
-            yen.Should().Be(new Money(765, "JPY"));
+            money.Should().Be(new Money(-98765, "JPY"));
         }
 
-        [Fact, UseCulture("en-US")]
+        [Fact, UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenParsingArgentinePesoInUSA_ThenThisShouldReturnArgentinePeso()
         {
-            var peso = Money.Parse("$765.43", Currency.FromCode("ARS"));
+            const string Value = "$-98,765.43";
+            var money = Money.Parse(Value, Currency.FromCode("ARS"));
 
-            peso.Should().Be(new Money(765.43m, "ARS"));
+            money.Should().Be(new Money(-98765.43m, "ARS"));
         }
 
-        [Fact, UseCulture("es-AR")]
+        [Fact, UseCulture(CultureNames.ArgentinaSpanish)]
         public void WhenParsingUSDollarSymbolInArgentina_ThenThisShouldReturnUSDollar()
         {
-            var dollar = Money.Parse("$765,43", Currency.FromCode("USD"));
+            const string Value = "$-98.765,43";
+            var money = Money.Parse(Value, Currency.FromCode("USD"));
 
-            dollar.Should().Be(new Money(765.43m, "USD"));
+            money.Should().Be(new Money(-98765.43m, "USD"));
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenParsingUSDollarInNetherlands_ThenThisShouldSucceed()
         {
             // $ symbol is used for multiple currencies
-            var dollar = Money.Parse("$765,43", Currency.FromCode("USD"));
+            const string Value = "$-98.765,43";
+            var money = Money.Parse(Value, Currency.FromCode("USD"));
 
-            dollar.Should().Be(new Money(765.43m, "USD"));
+            money.Should().Be(new Money(-98765.43m, "USD"));
         }
 
-        [Fact, UseCulture("nl-BE")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
+        public void WhenParsingSwissFrancInNetherlands_ThenThisShouldSucceed()
+        {
+            const string Value = "CHF-98.765,43";
+            var money = Money.Parse(Value, Currency.FromCode("CHF"));
+
+            money.Should().Be(new Money(-98765.43m, "CHF"));
+        }
+
+        [Fact, UseCulture(CultureNames.BelgiumDutch)]
         public void WhenInBelgiumDutchSpeaking_ThenThisShouldSucceed()
         {
-            var euro = Money.Parse("€ 765,43", Currency.FromCode("EUR"));
+            const string Value = "â‚¬ -98.765,43";
+            var money = Money.Parse(Value, Currency.FromCode("EUR"));
 
-            euro.Should().Be(new Money(765.43m, "EUR"));
+            money.Should().Be(new Money(-98765.43m, "EUR"));
         }
 
-        [Fact, UseCulture("fr-BE")]
+        [Fact, UseCulture(CultureNames.BelgiumFrench)]
         public void WhenInBelgiumFrenchSpeaking_ThenThisShouldSucceed()
         {
-            var euro = Money.Parse("765,43 €", Currency.FromCode("EUR"));
+            const string Value = "-98.765,43 â‚¬";
+            var money = Money.Parse(Value, Currency.FromCode("EUR"));
 
-            euro.Should().Be(new Money(765.43, "EUR"));
+            money.Should().Be(new Money(-98765.43, "EUR"));
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenParsingNumberWithoutCurrency_ThenThisShouldSucceed()
         {
-            var euro = Money.Parse("765,43", Currency.FromCode("USD"));
+            const string Value = "-98.765,43";
+            var money = Money.Parse(Value, Currency.FromCode("USD"));
 
-            euro.Should().Be(new Money(765.43, "USD"));
+            money.Should().Be(new Money(-98765.43, "USD"));
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenParsingUSDollarWithEuroCurrency_ThenThisShouldFail()
         {
-            Action action = () => Money.Parse("€ 765,43", Currency.FromCode("USD"));
+            const string Value = "â‚¬ -98.765,43";
+            Action action = () => Money.Parse(Value, Currency.FromCode("USD"));
 
             action.Should().Throw<FormatException>(); //.WithMessage("Input string was not in a correct format.");                
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenValueIsNull_ThenThowExeception()
         {
-            Action action = () => Money.Parse(null, Currency.FromCode("EUR"));
+            const string Value = null;
+            Action action = () => Money.Parse(Value, Currency.FromCode("EUR"));
 
             action.Should().Throw<ArgumentNullException>();
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenValueIsEmpty_ThenThowExeception()
         {
-            Action action = () => Money.Parse("", Currency.FromCode("EUR"));
+            const string Value = "";
+            Action action = () => Money.Parse(Value, Currency.FromCode("EUR"));
 
             action.Should().Throw<ArgumentNullException>();
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenValueIsNullWithOverrideMethod_ThenThowExeception()
         {
-            Action action = () => Money.Parse(null, NumberStyles.Currency, null, Currency.FromCode("EUR"));
+            const string Value = null;
+            Action action = () => Money.Parse(Value, NumberStyles.Currency, null, Currency.FromCode("EUR"));
 
             action.Should().Throw<ArgumentNullException>();
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenValueIsEmptyWithOverrideMethod_ThenThowExeception()
         {
-            Action action = () => Money.Parse("", NumberStyles.Currency, null, Currency.FromCode("EUR"));
+            const string Value = "";
+            Action action = () => Money.Parse(Value, NumberStyles.Currency, null, Currency.FromCode("EUR"));
 
             action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact, UseCulture(CultureNames.SwitzerlandGerman)]
+        public void WhenParsingSwissFrancInSwitzerlandGermanSpeaking_ThenThisShouldSucceed()
+        {
+            const string Value = "CHF-98â€™765.43";
+            var money = Money.Parse(Value, Currency.FromCode("CHF"));
+
+            money.Should().Be(new Money(-98765.43m, "CHF"));
         }
     }
 
     public class GivenIWantToParseNegativeMoney
     {
-        [Fact, UseCulture("en-US")]
+        [Fact, UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenMinusSignBeforeDollarSign_ThenThisShouldSucceed()
         {
-            string value = "-$765.43";
-            var dollar = Money.Parse(value);
+            const string Value = "-$98,765.43";
+            var money = Money.Parse(Value);
 
-            dollar.Should().Be(new Money(-765.43, "USD"));
+            money.Should().Be(new Money(-98765.43, "USD"));
         }
 
-        [Fact, UseCulture("en-US")]
+        [Fact, UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenMinusSignAfterDollarSign_ThenThisShouldSucceed()
         {
-            string value = "$-765.43";
-            var dollar = Money.Parse(value);
+            const string Value = "$-98,765.43";
+            var money = Money.Parse(Value);
 
-            dollar.Should().Be(new Money(-765.43, "USD"));
+            money.Should().Be(new Money(-98765.43, "USD"));
         }
 
-        [Fact, UseCulture("en-US")]
+        [Fact, UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenDollarsWithParentheses_ThenThisShouldSucceed()
         {
-            string value = "($765.43)";
-            var dollar = Money.Parse(value);
+            const string Value = "($98,765.43)";
+            var money = Money.Parse(Value);
 
-            dollar.Should().Be(new Money(-765.43, "USD"));
+            money.Should().Be(new Money(-98765.43, "USD"));
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenMinusSignBeforeEuroSign_ThenThisShouldSucceed()
         {
-            string value = "-€ 765,43";
-            var dollar = Money.Parse(value);
+            const string Value = "-â‚¬ 98.765,43";
+            var money = Money.Parse(Value);
 
-            dollar.Should().Be(new Money(-765.43, "EUR"));
+            money.Should().Be(new Money(-98765.43, "EUR"));
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenMinusSignAfterEuroSign_ThenThisShouldSucceed()
         {
-            string value = "€ -765,43";
-            var dollar = Money.Parse(value);
+            const string Value = "â‚¬ -98.765,43";
+            var money = Money.Parse(Value);
 
-            dollar.Should().Be(new Money(-765.43, "EUR"));
+            money.Should().Be(new Money(-98765.43, "EUR"));
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenEurosWithParentheses_ThenThisShouldSucceed()
         {
-            string value = "(€ 765,43)";
-            var dollar = Money.Parse(value);
+            const string Value = "(â‚¬ 98.765,43)";
+            var money = Money.Parse(Value);
 
-            dollar.Should().Be(new Money(-765.43, "EUR"));
+            money.Should().Be(new Money(-98765.43, "EUR"));
+        }
+
+        [Fact, UseCulture(CultureNames.SwitzerlandGerman)]
+        public void WhenMinusSignBeforeChfSign_ThenThisShouldSucceed()
+        {
+            const string Value = "-CHF 98â€™765.43";
+            var money = Money.Parse(Value);
+
+            money.Should().Be(new Money(-98765.43, "CHF"));
+        }
+
+        [Fact, UseCulture(CultureNames.SwitzerlandGerman)]
+        public void WhenMinusSignAfterCHFSign_ThenThisShouldSucceed()
+        {
+            const string Value = "CHF -98â€™765.43";
+            var money = Money.Parse(Value);
+
+            money.Should().Be(new Money(-98765.43, "CHF"));
+        }
+
+        [Fact, UseCulture(CultureNames.SwitzerlandGerman)]
+        public void WhenChfWithParentheses_ThenThisShouldSucceed()
+        {
+            const string Value = "(CHF 98â€™765.43)";
+            var money = Money.Parse(Value);
+
+            money.Should().Be(new Money(-98765.43, "CHF"));
         }
     }
 
     public class GivenIWantToParseMoneyWithMoreDecimalPossibleForCurrency
     {
-        [Fact, UseCulture("ja-JP")]
+        [Fact, UseCulture(CultureNames.JapanJapanese)]
         public void WhenParsingJapaneseYen_ThenThisShouldBeRoundedDown()
         {
-            var yen = Money.Parse("¥ 765.4");
+            const string Value = "Â¥ 98,765.4";
+            var money = Money.Parse(Value);
 
-            yen.Should().Be(new Money(765m, "JPY"));
+            money.Should().Be(new Money(98765m, "JPY"));
         }
 
-        [Fact, UseCulture("ja-JP")]
+        [Fact, UseCulture(CultureNames.JapanJapanese)]
         public void WhenParsingJapaneseYen_ThenThisShouldBeRoundedUp()
         {
-            var yen = Money.Parse("¥ 765.5");
+            const string Value = "Â¥ 98,765.5";
+            var money = Money.Parse(Value);
 
-            yen.Should().Be(new Money(766m, "JPY"));
+            money.Should().Be(new Money(98766m, "JPY"));
+        }
+
+        [Fact, UseCulture(CultureNames.SwitzerlandGerman)]
+        public void WhenParsingSwissFranc_ThenThisShouldBeRoundedUp()
+        {
+            const string Value = "CHF 98â€™765.475";
+            var money = Money.Parse(Value);
+
+            money.Should().Be(new Money(98765.48m, "CHF"));
         }
     }
 
     public class GivenIWantToTryParseImplicitCurrency
     {
-        [Fact, UseCulture("nl-BE")]
+        [Fact, UseCulture(CultureNames.BelgiumDutch)]
         public void WhenInBelgiumDutchSpeaking_ThenThisShouldSucceed()
         {
-            Money euro;
-            Money.TryParse("€ 765,43", out euro).Should().BeTrue();
+            const string Value = "â‚¬ -98.765,43";
+            Money.TryParse(Value, out Money money).Should().BeTrue();
 
-            euro.Should().Be(new Money(765.43m, "EUR"));
+            money.Should().Be(new Money(-98765.43m, "EUR"));
         }
 
-        [Fact, UseCulture("fr-BE")]
+        [Fact, UseCulture(CultureNames.BelgiumFrench)]
         public void WhenInBelgiumFrenchSpeaking_ThenThisShouldSucceed()
         {
-            Money euro;
-            Money.TryParse("765,43 €", out euro).Should().BeTrue();
+            const string Value = "-98.765,43 â‚¬";
+            Money.TryParse(Value, out Money money).Should().BeTrue();
 
-            euro.Should().Be(new Money(765.43, "EUR"));
+            money.Should().Be(new Money(-98765.43, "EUR"));
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenParsingNumberWithoutCurrency_ThenThisUseCurrencyOfCurrentCulture()
         {
-            Money euro;
-            Money.TryParse("765,43", out euro).Should().BeTrue();
+            const string Value = "-98.765,43";
+            Money.TryParse(Value, out Money money).Should().BeTrue();
 
-            euro.Should().Be(new Money(765.43, "EUR"));
+            money.Should().Be(new Money(-98765.43, "EUR"));
         }
 
-        [Fact, UseCulture("ja-JP")]
+        [Fact, UseCulture(CultureNames.JapanJapanese)]
         public void WhenParsingYenYuanSymbolInJapan_ThenThisShouldReturnJapaneseYen()
         {
-            Money yen;
-            Money.TryParse("¥ 765", out yen).Should().BeTrue();
+            const string Value = "Â¥ -98,765";
+            Money.TryParse(Value, out Money money).Should().BeTrue();
 
-            yen.Should().Be(new Money(765m, "JPY"));
+            money.Should().Be(new Money(-98765m, "JPY"));
         }
 
-        [Fact, UseCulture("zh-CN")]
+        [Fact, UseCulture(CultureNames.ChinaMainlandChinese)]
         public void WhenParsingYenYuanSymbolInChina_ThenThisShouldReturnChineseYuan()
         {
-            Money yuan;
-            Money.TryParse("¥ 765", out yuan).Should().BeTrue();
+            const string Value = "Â¥ -98,765";
+            Money.TryParse(Value, out Money money).Should().BeTrue();
 
-            yuan.Should().Be(new Money(765m, "CNY"));
+            money.Should().Be(new Money(-98765m, "CNY"));
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenParsingYenYuanInNetherlands_ThenThisShouldReturnFalse()
         {
-            // ¥ symbol is used for Japanese yen and Chinese yuan
-            Money money;
-            Money.TryParse("¥ 765", out money).Should().BeFalse();
+            // Â¥ symbol is used for Japanese money and Chinese money
+            const string Value = "Â¥ -98,765";
+            Money.TryParse(Value, out Money money).Should().BeFalse();
 
             money.Should().Be(new Money(0m, Currency.FromCode("XXX")));
         }
 
-        [Fact, UseCulture("en-US")]
+        [Fact, UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenParsingDollarSymbolInUSA_ThenThisShouldReturnUSDollar()
         {
-            Money dollar;
-            Money.TryParse("$765.43", out dollar).Should().BeTrue();
+            const string Value = "$-98,765.43";
+            Money.TryParse(Value, out Money money).Should().BeTrue();
 
-            dollar.Should().Be(new Money(765.43m, "USD"));
+            money.Should().Be(new Money(-98765.43m, "USD"));
         }
 
-        [Fact, UseCulture("es-AR")]
+        [Fact, UseCulture(CultureNames.ArgentinaSpanish)]
         public void WhenParsingDollarSymbolInArgentina_ThenThisShouldReturnArgentinePeso()
         {
-            Money peso;
-            Money.TryParse("$765,43", out peso).Should().BeTrue();
+            const string Value = "$-98.765,43";
+            Money.TryParse(Value, out Money money).Should().BeTrue();
 
-            peso.Should().Be(new Money(765.43m, "ARS"));
+            money.Should().Be(new Money(-98765.43m, "ARS"));
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenParsingDollarSymbolInNetherlands_ThenThisShouldReturnFalse()
         {
             // $ symbol is used for multiple currencies
-            Money money;
-            Money.TryParse("$ 765,43", out money).Should().BeFalse();
+            const string Value = "$ -98.765,43";
+            Money.TryParse(Value, out Money money).Should().BeFalse();
 
             money.Should().Be(new Money(0m, Currency.FromCode("XXX")));
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenValueIsNull_ThenReturnFalse()
         {
-            Money money;
-            Money.TryParse(null, out money).Should().BeFalse();
+            const string Value = null;
+            Money.TryParse(Value, out Money money).Should().BeFalse();
 
             money.Should().Be(new Money(0m, Currency.FromCode("XXX")));
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenValueIsEmpty_ThenReturnFalse()
         {
-            Money money;
-            Money.TryParse("", out money).Should().BeFalse();
+            const string Value = "";
+            Money.TryParse(Value, out Money money).Should().BeFalse();
 
             money.Should().Be(new Money(0m, Currency.FromCode("XXX")));
+        }
+
+        [Fact, UseCulture(CultureNames.SwitzerlandGerman)]
+        public void WhenInSwitzerlandGermanSpeaking_ThenThisShouldSucceed()
+        {
+            const string Value = "CHF -98â€™765.43";
+            Money.TryParse(Value, out Money money).Should().BeTrue();
+
+            money.Should().Be(new Money(-98765.43m, "CHF"));
         }
     }
 
     public class GivenIWantToTryParseExplicitCurrency
     {
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenParsingYenInNetherlands_ThenThisShouldSucceed()
         {
-            Money yen;
-            Money.TryParse("¥ 765", Currency.FromCode("JPY"), out yen).Should().BeTrue();
+            const string Value = "Â¥ -98.765";
+            Money.TryParse(Value, Currency.FromCode("JPY"), out Money money).Should().BeTrue();
 
-            yen.Should().Be(new Money(765, "JPY"));
+            money.Should().Be(new Money(-98765m, "JPY"));
         }
 
-        [Fact, UseCulture("en-US")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
+        public void WhenParsingSwissFrancInNetherlands_ThenThisShouldSucceed()
+        {
+            const string Value = "CHF -98.765";
+            Money.TryParse(Value, Currency.FromCode("CHF"), out Money money).Should().BeTrue();
+
+            money.Should().Be(new Money(-98765m, "CHF"));
+        }
+
+        [Fact, UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenParsingArgentinePesoInUSA_ThenThisShouldReturnArgentinePeso()
         {
-            Money peso;
-            Money.TryParse("$765.43", Currency.FromCode("ARS"), out peso).Should().BeTrue();
+            const string Value = "$-98,765.43";
+            Money.TryParse(Value, Currency.FromCode("ARS"), out Money money).Should().BeTrue();
 
-            peso.Should().Be(new Money(765.43m, "ARS"));
+            money.Should().Be(new Money(-98765.43m, "ARS"));
         }
 
-        [Fact, UseCulture("es-AR")]
+        [Fact, UseCulture(CultureNames.ArgentinaSpanish)]
         public void WhenParsingUSDollarSymbolInArgentina_ThenThisShouldReturnUSDollar()
         {
-            Money dollar;
-            Money.TryParse("$765,43", Currency.FromCode("USD"), out dollar).Should().BeTrue();
+            const string Value = "$-98.765,43";
+            Money.TryParse(Value, Currency.FromCode("USD"), out Money money).Should().BeTrue();
 
-            dollar.Should().Be(new Money(765.43m, "USD"));
+            money.Should().Be(new Money(-98765.43m, "USD"));
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenParsingUSDollarInNetherlands_ThenThisShouldSucceed()
         {
             // $ symbol is used for multiple currencies
-            Money dollar;
-            Money.TryParse("$765,43", Currency.FromCode("USD"), out dollar).Should().BeTrue();
+            const string Value = "$-98.765,43";
+            Money.TryParse(Value, Currency.FromCode("USD"), out Money money).Should().BeTrue();
 
-            dollar.Should().Be(new Money(765.43m, "USD"));
+            money.Should().Be(new Money(-98765.43m, "USD"));
         }
 
-        [Fact, UseCulture("nl-BE")]
+        [Fact, UseCulture(CultureNames.BelgiumDutch)]
         public void WhenInBelgiumDutchSpeaking_ThenThisShouldSucceed()
         {
-            Money euro;
-            Money.TryParse("€ 765,43", Currency.FromCode("EUR"), out euro).Should().BeTrue();
+            const string Value = "â‚¬ -98.765,43";
+            Money.TryParse(Value, Currency.FromCode("EUR"), out Money money).Should().BeTrue();
 
-            euro.Should().Be(new Money(765.43m, "EUR"));
+            money.Should().Be(new Money(-98765.43m, "EUR"));
         }
 
-        [Fact, UseCulture("fr-BE")]
+        [Fact, UseCulture(CultureNames.BelgiumFrench)]
         public void WhenInBelgiumFrenchSpeaking_ThenThisShouldSucceed()
         {
-            Money euro;
-            Money.TryParse("765,43 €", Currency.FromCode("EUR"), out euro).Should().BeTrue();
+            const string Value = "-98.765,43 â‚¬";
+            Money.TryParse(Value, Currency.FromCode("EUR"), out Money money).Should().BeTrue();
 
-            euro.Should().Be(new Money(765.43, "EUR"));
+            money.Should().Be(new Money(-98765.43, "EUR"));
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenParsingNumberWithoutCurrency_ThenThisShouldSucceed()
         {
-            Money euro;
-            Money.TryParse("765,43", Currency.FromCode("USD"), out euro).Should().BeTrue();
+            const string Value = "-98.765,43";
+            Money.TryParse(Value, Currency.FromCode("USD"), out Money money).Should().BeTrue();
 
-            euro.Should().Be(new Money(765.43, "USD"));
+            money.Should().Be(new Money(-98765.43, "USD"));
         }
 
-        [Fact, UseCulture("nl-NL")]
+        [Fact, UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenParsingUSDollarWithEuroCurrency_ThenThisShouldReturnFalse()
         {
-            Money money;
-            Money.TryParse("€ 765,43", Currency.FromCode("USD"), out money).Should().BeFalse();
+            const string Value = "â‚¬ -98.765,43";
+            Money.TryParse(Value, Currency.FromCode("USD"), out Money money).Should().BeFalse();
 
             money.Should().Be(new Money(0m, Currency.FromCode("XXX")));
+        }
+
+        [Fact, UseCulture(CultureNames.SwitzerlandGerman)]
+        public void WhenParsingSwissFrancInSwitzerlandGermanSpeaking_ThenThisShouldSucceed()
+        {
+            const string Value = "CHF -98â€™765";
+            Money.TryParse(Value, Currency.FromCode("CHF"), out Money money).Should().BeTrue();
+
+            money.Should().Be(new Money(-98765m, "CHF"));
         }
     }
 }

--- a/tests/NodaMoney.Tests/MoneySpec.cs
+++ b/tests/NodaMoney.Tests/MoneySpec.cs
@@ -15,29 +15,29 @@ namespace NodaMoney.Tests.MoneySpec
         private readonly decimal _decimalValue = 1234.567m;
 
         [Fact]
-        [UseCulture("en-US")]
+        [UseCulture(CultureNames.UnitedStatesEnglish)]
         public void WhenCurrentCultureIsUS_ThenCreatingShouldSucceed()
         {            
             var money = new Money(_decimalValue);
 
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.UnitedStatesEnglish);
             money.Currency.Should().Be(Currency.FromCode("USD"));
             money.Amount.Should().Be(1234.57m);
         }
 
         [Fact]
-        [UseCulture("nl-NL")]
+        [UseCulture(CultureNames.NetherlandsDutch)]
         public void WhenCurrentCultureIsNL_ThenCreatingShouldSucceed()
         {
             var money = new Money(_decimalValue);
 
-            Thread.CurrentThread.CurrentCulture.Name.Should().Be("nl-NL");
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be(CultureNames.NetherlandsDutch);
             money.Currency.Should().Be(Currency.FromCode("EUR"));
             money.Amount.Should().Be(1234.57m);
         }
 
         [Fact]
-        [UseCulture("ja-JP")]
+        [UseCulture(CultureNames.JapanJapanese)]
         public void WhenCurrentCultureIsJP_ThenCreatingShouldSucceed()
         {
             var money = new Money(_decimalValue);
@@ -48,7 +48,7 @@ namespace NodaMoney.Tests.MoneySpec
         }
 
         [Fact]
-        [UseCulture(null)]
+        [UseCulture(CultureNames.Invariant)]
         public void WhenCurrentCultureIsInvariant_ThenThisShouldThrowException()
         {
             Action action = () => { var money = new Money(_decimalValue); };


### PR DESCRIPTION
- ToString/Parse round-trip failed because of '.' in "fr." (and possibly other currencies with a '.' in their symbol)
- replaced unused/outdated symbol "fr." by "CHF"

- added NodaMoney.CurrencySymbolParser, provided unit tests
- added NodaMoney.Tests.Helpers.CultureNames with constants used by several unit tests
- added NodaMoney.Currency.GetCurrencies(string symbol) with a cached lookup
- modified NodaMoney.CurrencyRegistry
  - made static fields into instance fields
  - introduced helper method GetKey
  - removes namespace when empty
  - maintains a lookup for currency resolution by symbol
  - added GetCurrencies(string symbol)
- reworked NodaMoney.Money.ExtractCurrencyFromString
  - replaced insufficient IsNotNumericCharacter by CurrencySymbolParser.Parse
  - replaced inefficient Currency.GetAllCurrencies().Where(...) by Currency.GetCurrencies(symbol) and Currency.Registry.TryGet(code)
- added NodaMoney.Tests.MoneyFormattableSpec.GivenIWantMoneyAsString._swissFranc and corresponding unit tests
- added NodaMoney.Tests.MoneyFormattableSpec.GivenIWantMoneyAsStringWithCurrencySymbol._swissFranc and corresponding unit tests
- added NodaMoney.Tests.MoneyFormattableSpec.GivenIWantMoneyAsStringWithCurrencyCode._swissFranc and corresponding unit tests
- added NodaMoney.Tests.MoneyFormattableSpec.GivenIWantMoneyAsStringWithEnglishCurrencyName._swissFranc and corresponding unit tests
- modified unit tests in NodaMoney.Tests.MoneyParsableSpec
  - unified naming and setup
  - added unit tests related to Swiss Francs