### PR TITLE
More defensive parsing in JSON converters

### DIFF
--- a/src/NodaMoney/Money.Parsable.cs
+++ b/src/NodaMoney/Money.Parsable.cs
@@ -171,6 +171,12 @@ public partial struct Money
     {
         try
         {
+            if (s.IsEmpty || s.IsWhiteSpace())
+            {
+                result = new Money(0, CurrencyInfo.NoCurrency);
+                return false;
+            }
+
             ReadOnlySpan<char> currencyChars = ParseSymbol(s);
 
             CurrencyInfo currencyInfo = (provider is CurrencyInfo ci) ? ParseCurrencyInfo(currencyChars, ci) : ParseCurrencyInfo(currencyChars);


### PR DESCRIPTION
PR to not rely on exceptions to handle what is common serialization formats. E.g Google product feed use "25.00 USD" for monetary values.

Maybe what is needed is a TryParseExact method on Money, so that this handling could be more DRY.