### PR TITLE
More Exchange rate fixes

### DIFF
--- a/tests/NodaMoney.Tests/ExchangeRateSpec/ConvertExchangeRateToString.cs
+++ b/tests/NodaMoney.Tests/ExchangeRateSpec/ConvertExchangeRateToString.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using NodaMoney.Exchange;
 using NodaMoney.Tests.Helpers;
 
@@ -18,5 +19,18 @@ public class ConvertExchangeRateToString
     public void WhenShowingExchangeRateInNetherlands_ThenReturnCurrencyPairWithComma()
     {
         fx.ToString().Should().Be("EUR/USD 1,2524");
+    }
+
+    [Fact, UseCulture("nl-NL")]
+    public void WhenShowingExchangeRateInNetherlands_ThenReturnCurrencyPairWithDotWhenInvariantCultureIsSpecified()
+    {
+        fx.ToString(CultureInfo.InvariantCulture).Should().Be("EUR/USD 1.2524");
+    }
+
+    [Fact]
+    public void WhenShowingExchangeRateWithSpecifiedCulture_ThenReturnCurrencyAccordingly()
+    {
+        fx.ToString(CultureInfo.GetCultureInfo("en-US")).Should().Be("EUR/USD 1.2524");
+        fx.ToString(CultureInfo.GetCultureInfo("nl-NL")).Should().Be("EUR/USD 1,2524");
     }
 }

--- a/tests/NodaMoney.Tests/ExchangeRateSpec/ParseACurrencyPair.cs
+++ b/tests/NodaMoney.Tests/ExchangeRateSpec/ParseACurrencyPair.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using NodaMoney.Exchange;
 using NodaMoney.Tests.Helpers;
 
@@ -38,6 +39,24 @@ public class ParseACurrencyPair
         fx2.Value.Should().Be(1.2591M);
     }
 
+    [Fact, UseCulture("en-US")]
+    public void WhenCurrencyPairInNlCulture_ThenParsingShouldSucceedWithCultureSpecified()
+    {
+        var fx = ExchangeRate.Parse("EUR/USD 1,2591", CultureInfo.GetCultureInfo("nl-NL"));
+
+        fx.BaseCurrency.Code.Should().Be("EUR");
+        fx.QuoteCurrency.Code.Should().Be("USD");
+        fx.Value.Should().Be(1.2591M);
+    }
+
+    [Fact, UseCulture("nl-NL")]
+    public void WhenCurrencyPairInNlCulture_ThenParsingShouldFailWithIncompatibleCultureSpecified()
+    {
+        Action action = () => ExchangeRate.Parse("EUR/USD 1,2591", NumberStyles.Currency & ~NumberStyles.AllowThousands, CultureInfo.GetCultureInfo("en-US"));
+
+        action.Should().Throw<FormatException>();
+    }
+
     [Fact]
     public void WhenCurrencyPairIsNotANumber_ThenThrowException()
     {
@@ -47,7 +66,17 @@ public class ParseACurrencyPair
     }
 
     [Fact, UseCulture("en-US")]
-    public void WhenCurrencyPairHasSameCurrencies_ThenThrowException()
+    public void WhenCurrencyPairHasSameCurrenciesAndValueEqualTo1_ThenParsingShouldSucceed()
+    {
+        var fx1 = ExchangeRate.Parse("EUR/EUR 1");
+
+        fx1.BaseCurrency.Code.Should().Be("EUR");
+        fx1.QuoteCurrency.Code.Should().Be("EUR");
+        fx1.Value.Should().Be(1M);
+    }
+
+    [Fact, UseCulture("en-US")]
+    public void WhenCurrencyPairHasSameCurrenciesAndValueNotEqualTo1_ThenThrowException()
     {
         Action action = () => ExchangeRate.Parse("EUR/EUR 1.2591");
 

--- a/tests/NodaMoney.Tests/ExchangeRateSpec/TryParseACurrencyPair.cs
+++ b/tests/NodaMoney.Tests/ExchangeRateSpec/TryParseACurrencyPair.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using NodaMoney.Exchange;
 using NodaMoney.Tests.Helpers;
 
@@ -9,16 +10,14 @@ public class TryParseACurrencyPair
     [Fact, UseCulture("en-US")]
     public void WhenCurrencyPairInUsCulture_ThenParsingShouldSucceed()
     {
-        ExchangeRate fx1;
-        var succeeded1 = ExchangeRate.TryParse("EUR/USD 1.2591", out fx1);
+        var succeeded1 = ExchangeRate.TryParse("EUR/USD 1.2591", out ExchangeRate fx1);
 
         succeeded1.Should().BeTrue();
         fx1.BaseCurrency.Code.Should().Be("EUR");
         fx1.QuoteCurrency.Code.Should().Be("USD");
         fx1.Value.Should().Be(1.2591M);
 
-        ExchangeRate fx2;
-        var succeeded2 = ExchangeRate.TryParse("EUR/USD1.2591", out fx2);
+        var succeeded2 = ExchangeRate.TryParse("EUR/USD1.2591", out ExchangeRate fx2);
 
         succeeded2.Should().BeTrue();
         fx2.BaseCurrency.Code.Should().Be("EUR");
@@ -29,16 +28,14 @@ public class TryParseACurrencyPair
     [Fact, UseCulture("nl-NL")]
     public void WhenCurrencyPairInNlCulture_ThenParsingShouldSucceed()
     {
-        ExchangeRate fx1;
-        var succeeded1 = ExchangeRate.TryParse("EUR/USD 1,2591", out fx1);
+        var succeeded1 = ExchangeRate.TryParse("EUR/USD 1,2591", out ExchangeRate fx1);
 
         succeeded1.Should().BeTrue();
         fx1.BaseCurrency.Code.Should().Be("EUR");
         fx1.QuoteCurrency.Code.Should().Be("USD");
         fx1.Value.Should().Be(1.2591M);
 
-        ExchangeRate fx2;
-        var succeeded2 = ExchangeRate.TryParse("EUR/USD1,2591", out fx2);
+        var succeeded2 = ExchangeRate.TryParse("EUR/USD1,2591", out ExchangeRate fx2);
 
         succeeded2.Should().BeTrue();
         fx2.BaseCurrency.Code.Should().Be("EUR");
@@ -46,11 +43,32 @@ public class TryParseACurrencyPair
         fx2.Value.Should().Be(1.2591M);
     }
 
+    [Fact, UseCulture("en-US")]
+    public void WhenCurrencyPairInNlCulture_ThenParsingShouldSucceedWithCultureSpecified()
+    {
+        var succeeded = ExchangeRate.TryParse("EUR/USD 1,2591", CultureInfo.GetCultureInfo("nl-NL"), out ExchangeRate fx);
+
+        succeeded.Should().BeTrue();
+        fx.BaseCurrency.Code.Should().Be("EUR");
+        fx.QuoteCurrency.Code.Should().Be("USD");
+        fx.Value.Should().Be(1.2591M);
+    }
+
+    [Fact, UseCulture("nl-NL")]
+    public void WhenCurrencyPairInNlCulture_ThenParsingShouldFailWithIncompatibleCultureSpecified()
+    {
+        var succeeded = ExchangeRate.TryParse("EUR/USD 1,2591", NumberStyles.Currency & ~NumberStyles.AllowThousands, CultureInfo.GetCultureInfo("en-US"), out ExchangeRate fx);
+
+        succeeded.Should().BeFalse();
+        fx.BaseCurrency.Code.Should().Be("XXX");
+        fx.QuoteCurrency.Code.Should().Be("XXX");
+        fx.Value.Should().Be(0M);
+    }
+
     [Fact]
     public void WhenCurrencyPairIsNotANumber_ThenParsingFails()
     {
-        ExchangeRate fx;
-        var succeeded = ExchangeRate.TryParse("EUR/USD 1,ABC", out fx);
+        var succeeded = ExchangeRate.TryParse("EUR/USD 1,ABC", out ExchangeRate fx);
 
         succeeded.Should().BeFalse();
         fx.BaseCurrency.Code.Should().Be("XXX");
@@ -61,10 +79,20 @@ public class TryParseACurrencyPair
     }
 
     [Fact, UseCulture("en-US")]
-    public void WhenCurrencyPairHasSameCurrencies_ThenParsingFails()
+    public void WhenCurrencyPairHasSameCurrenciesAndValueEqualTo1_ThenParsingShouldSucceed()
     {
-        ExchangeRate fx;
-        var succeeded = ExchangeRate.TryParse("EUR/EUR 1.2591", out fx);
+        var succeeded = ExchangeRate.TryParse("EUR/EUR 1", out ExchangeRate fx);
+
+        succeeded.Should().BeTrue();
+        fx.BaseCurrency.Code.Should().Be("EUR");
+        fx.QuoteCurrency.Code.Should().Be("EUR");
+        fx.Value.Should().Be(1M);
+    }
+
+    [Fact, UseCulture("en-US")]
+    public void WhenCurrencyPairHasSameCurrenciesAndValueNotEqualTo1_ThenParsingFails()
+    {
+        var succeeded = ExchangeRate.TryParse("EUR/EUR 1.2591", out ExchangeRate fx);
 
         succeeded.Should().BeFalse();
         fx.BaseCurrency.Code.Should().Be("XXX");
@@ -77,8 +105,7 @@ public class TryParseACurrencyPair
     [Fact]
     public void WhenCurrencyPairIsNull_ThenParsingFails()
     {
-        ExchangeRate fx;
-        var succeeded = ExchangeRate.TryParse(null, out fx);
+        var succeeded = ExchangeRate.TryParse(null, out ExchangeRate fx);
 
         succeeded.Should().BeFalse();
         fx.BaseCurrency.Code.Should().Be("XXX");
@@ -91,8 +118,7 @@ public class TryParseACurrencyPair
     [Fact]
     public void WhenCurrencyPairIsEmpty_ThenParsingFails()
     {
-        ExchangeRate fx;
-        var succeeded = ExchangeRate.TryParse("", out fx);
+        var succeeded = ExchangeRate.TryParse("", out ExchangeRate fx);
 
         succeeded.Should().BeFalse();
         fx.BaseCurrency.Code.Should().Be("XXX");


### PR DESCRIPTION
- Added tests for the "allow same currency with value 1" fix.
- Added ToString, Parse and TryParse overloads with IFormatProvider and NumberStyles
- Breaking. IMHO a TryParse shouldn't throw an ArgumentNullException, especially not for non-null values. 